### PR TITLE
[Improve] Add a bundle management for non SPM integration

### DIFF
--- a/Sources/Core/Documentation.docc/Documentation.md
+++ b/Sources/Core/Documentation.docc/Documentation.md
@@ -16,10 +16,10 @@ It can manage a simple numeric number or a complexe format (currency, percent, .
 ### Rendering
 
 With a numeric number
-![Stepper rendering.](component.png)
+![Component rendering.](component.png)
 
 With a currency 
-![Stepper rendering.](component_with_format.png)
+![Component rendering.](component_with_format.png)
 
 ### Resources
 

--- a/Sources/Core/Extension/Bundle+CurrentExtension.swift
+++ b/Sources/Core/Extension/Bundle+CurrentExtension.swift
@@ -1,0 +1,27 @@
+//
+//  Bundle+CurrentExtension.swift
+//  SparkStepper
+//
+//  Created by robin.lemaire on 26/02/2025.
+//  Copyright © 2025 Leboncoin. All rights reserved.
+//
+
+import Foundation
+import SparkTheming
+
+extension Bundle {
+
+    // MARK: - Class
+
+    private final class Class {}
+
+    // MARK: - Static Properties
+
+    static var current: Bundle {
+#if SWIFT_PACKAGE
+        Bundle.module
+#else
+        Bundle(for: Class.self)
+#endif
+    }
+}

--- a/Sources/Core/UseCase/StepperGetAccessibilityLabelUseCase.swift
+++ b/Sources/Core/UseCase/StepperGetAccessibilityLabelUseCase.swift
@@ -19,6 +19,12 @@ protocol StepperGetAccessibilityLabelUseCaseable {
 
 struct StepperGetAccessibilityLabelUseCase: StepperGetAccessibilityLabelUseCaseable {
 
+    // MARK: - Class
+
+    private final class Class {}
+
+    // MARK: - Execute
+
     func execute(
         for type: StepperButtonType,
         customLabel: String?,
@@ -28,7 +34,7 @@ struct StepperGetAccessibilityLabelUseCase: StepperGetAccessibilityLabelUseCasea
             return customLabel
         } else {
             let localizedKey = self.execute(for: type, text: text)
-            return String(localized: localizedKey, bundle: .module)
+            return String(localized: localizedKey, bundle: .current)
         }
     }
 


### PR DESCRIPTION
Leboncoin use the spark dependencies as binary and not SPM, so the .module on Bundle doesn't exists on this context.
This PR fix the issue.